### PR TITLE
Stop requiring uwsgi to be installed by pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,5 @@ setup(
     ],
     install_requires=[
         'Django',
-        'uWSGI',
     ]
 )


### PR DESCRIPTION
No need to have uwsgi installed by pip you just need it at runtime.