### PR TITLE
Check DEFAULT_TIMEOUT (Django 1.6+)

### DIFF
--- a/src/uwsgicache.py
+++ b/src/uwsgicache.py
@@ -5,7 +5,7 @@ try:
     from django.utils.encoding import force_bytes as stringify
 except ImportError:
     from django.utils.encoding import smart_str as stringify
-from django.core.cache.backends.base import BaseCache, InvalidCacheBackendError
+from django.core.cache.backends.base import BaseCache, InvalidCacheBackendError, DEFAULT_TIMEOUT
 from django.conf import settings
 
 try:
@@ -52,9 +52,10 @@ if uwsgi:
             return pickle.loads(val)
 
         def _set(self, full_key, value, timeout):
-            if timeout is True:
+            if timeout is True or timeout == DEFAULT_TIMEOUT:
                 uwsgi_timeout = self.default_timeout
-            elif timeout is None or timeout is False:
+
+            if timeout is None or timeout is False:
                 # Django 1.6+: Explicitly passing in timeout=None will set a non-expiring timeout.
                 uwsgi_timeout = 0
             elif timeout == 0:


### PR DESCRIPTION
There is a new `DEFAULT_TIMEOUT` value in Django which is checked when timeout is not set.
It has been introduced in:
https://github.com/django/django/commit/89955cc35f3636684ea6f2a6c9504b35a3050f0f

The problem was that this has been passed to uWSGI as it was, because it has not been checked and the uWSGI cache_update function expected an integer not an object() instace, so it gave a TypeError.

Also check settings.py default values the same way as it be would passed to function call.
(So we need to check every value in _set() which comes from settings.py.)