### PR TITLE
Modify Django and uWSGI version constraints

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     process-tests
     httpx
     setuptools>=80
-    uWSGI>=2.0.30,<2.1 
+    uWSGI>=2.0.30,<2.1
     dj42: django>4.2<5
     dj52: django>5.2<6
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,8 @@ deps =
     httpx
     setuptools>=80
     uWSGI>=2.0.30,<2.1
-    dj42: django>4.2<5
-    dj52: django>5.2<6
+    dj42: django>4.2,<5
+    dj52: django>5.2,<6
 commands =
     {posargs:pytest --cov --cov-report=term-missing --cov-report=xml -vv tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,9 +35,9 @@ deps =
     process-tests
     httpx
     setuptools>=80
-    uWSGI==2.0.30
-    dj42: django==4.2.24
-    dj52: django==5.2.6
+    uWSGI>=2.0.30,<2.1
+    dj42: django>4.2<5
+    dj52: django>5.2<6
 commands =
     {posargs:pytest --cov --cov-report=term-missing --cov-report=xml -vv tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     process-tests
     httpx
     setuptools>=80
-    uWSGI>=2.0.30,<2.1
+    uWSGI>=2.0.30,<2.1 
     dj42: django>4.2<5
     dj52: django>5.2<6
 commands =


### PR DESCRIPTION
Updated Django and uWSGI version specifications in tox.ini.

[Tests running here](https://github.com/kingbuzzman/django-uwsgi-cache/pull/1)

Please squash this PR, the history of the commits are not important.